### PR TITLE
add explicit return

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ fastify.get('/:database/:z/:x/:y', async (request, reply) => {
       }
     }
   )
+  return reply
 })
 
 // MBtiles meta route
@@ -77,6 +78,7 @@ fastify.get('/:database/meta', async (request, reply) => {
       reply.send(rows)
     }
   })
+  return reply
 })
 
 // MBtiles list


### PR DESCRIPTION
Why:
* Without this, an error is logged: FST_ERR_PROMISE_NOT_FULLFILLED Promise may not be fulfilled with 'undefined' when statusCode is not 204
* To reproduce this error, you would need to change the first line of the file to `const fastify = require('fastify')({ logger: true })`

How:
* Include `return reply` at the end of the `fastify.get`
* Did not include this in the /list endpoint, because it didn't resolve the issue for some reason (neither did `await reply`)

Related Links:
* https://github.com/fastify/help/issues/52
* https://www.fastify.io/docs/latest/Routes/#async-await
* https://twitter.com/JamesChevalier/status/1222976991579774977